### PR TITLE
Fixing UI for Admin Commons List page

### DIFF
--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -50,32 +50,32 @@ export default function CommonsTable({ commons, currentUser }) {
             accessor: 'commons.name',
         },
         {
-            Header:'Cow Price',
+            Header: <small>Cow<br />Price</small>,
             accessor: row => row.commons.cowPrice,
             id: 'commons.cowPrice'
         },
         {
-            Header:'Milk Price',
+            Header: <small>Milk<br />Price</small>,
             accessor: row => row.commons.milkPrice,
             id: 'commons.milkPrice'
         },
         {
-            Header:'Starting Balance',
+            Header: <small>Starting<br />Balance</small>,
             accessor: row => row.commons.startingBalance,
             id: 'commons.startingBalance'
         },
         {
-            Header:'Starting Date',
+            Header: <span>Starting<br />Date</span>,
             accessor: row => String(row.commons.startingDate).slice(0,10),
             id: 'commons.startingDate'
         },
         {
-            Header:'Degradation Rate',
+            Header: <small>Degrad.<br />Rate</small>,
             accessor: row => row.commons.degradationRate,
             id: 'commons.degradationRate'
         },
         {
-            Header:'Show Leaderboard?',
+            Header: <small>Show<br />Ldrboard</small>,
             id: 'commons.showLeaderboard', // needed for tests
             accessor: (row, _rowIndex) => String(row.commons.showLeaderboard) // hack needed for boolean values to show up
         },
@@ -84,17 +84,17 @@ export default function CommonsTable({ commons, currentUser }) {
             accessor: 'totalCows'
         },
         {
-            Header: 'Capacity Per User',
+            Header: <small>Cap.<br />Per User</small>,
             accessor: row => row.commons.capacityPerUser,
             id: 'commons.capacityPerUser'
         },
         {
-            Header: 'Carrying Capacity',
+            Header: <small>Carrying<br />Cap.</small>,
             accessor: row => row.commons.carryingCapacity,
             id: 'commons.carryingCapacity'
         },
         {
-            Header: 'Effective Capacity',
+            Header: <small>Effective<br />Cap.</small>,
             accessor: 'effectiveCapacity'
         }
     ];

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -69,12 +69,12 @@ describe("UserTable tests", () => {
 
     );
 
-    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Degradation Rate', 'Capacity Per User', 'Carrying Capacity', "Effective Capacity",'Cows', 'Show Leaderboard?'];
+    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Degrad. Rate', 'Cap. Per User', 'Carrying Cap.', "Effective Cap.",'Cows', 'Show Ldrboard'];
     const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "degradationRate", "capacityPerUser", "carryingCapacity"];
     const testId = "CommonsTable";
 
     expectedHeaders.forEach((headerText) => {
-      const header = screen.getByText(headerText);
+      const header = screen.getByText(new RegExp(headerText.replace(/\s+/g, "\\s*"), "i"));
       expect(header).toBeInTheDocument();
     });
 


### PR DESCRIPTION
In this PR, we adjust the headers of the admin commons list page to show more on the page without having to scroll. 

Before:
![Screenshot (718)](https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-2/assets/114687823/b18658e7-e711-40a4-bc18-48fb8d597152)

After:
![Screenshot (719)](https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-2/assets/114687823/a18ed9ca-5c06-459b-9cfb-b2a03444cca5)

Link to personal dev deployment: https://happycows-bradenc24-dev.dokku-02.cs.ucsb.edu

Closes #15 