### PR TITLE
Hancheng default commons UI

### DIFF
--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -31,10 +31,11 @@ const CommonsList = (props) => {
                 </Container>
             </Card.Subtitle>
             {
-                props.commonList &&
-                props.commonList.map(
-                    (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} />)
-                )
+                props.commonList && props.commonList.length > 0 ?
+                props.commonList.map((c) => (
+                    <CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} />
+                )) :
+                <div className="text-center my-3">Currently, there are no commons available.</div>
             }
         </Card>
     );

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -24,12 +24,6 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             accessor: (row, _rowIndex) => {
                 return USD.format(row.totalWealth);
             },
-            // sortType: 
-            //     (rowA,rowB,_id,_desc)=>{
-            //         // const diff = parseFloat() - parseFloat(rowB.original.totalWealth);
-            //         return rowA.original.totalWealth - rowB.original.totalWealth;
-            //     }
-            // ,
             Cell: (props) => {
                 return (
                   <div style={{textAlign: "right"}}>{props.value}</div>)

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -27,7 +27,7 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             Cell: (props) => {
                 return (
                   <div style={{textAlign: "right"}}>{props.value}</div>)
-                },
+                  },
         },
         {
             Header: 'Cows Owned',

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -27,7 +27,7 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             Cell: (props) => {
                 return (
                   <div style={{textAlign: "right"}}>{props.value}</div>)
-            },
+                },
         },
         {
             Header: 'Cows Owned',

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -24,10 +24,16 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             accessor: (row, _rowIndex) => {
                 return USD.format(row.totalWealth);
             },
+            // sortType: 
+            //     (rowA,rowB,_id,_desc)=>{
+            //         // const diff = parseFloat() - parseFloat(rowB.original.totalWealth);
+            //         return rowA.original.totalWealth - rowB.original.totalWealth;
+            //     }
+            // ,
             Cell: (props) => {
                 return (
                   <div style={{textAlign: "right"}}>{props.value}</div>)
-                  },
+            },
         },
         {
             Header: 'Cows Owned',

--- a/frontend/src/tests/components/Commons/CommonsList.test.js
+++ b/frontend/src/tests/components/Commons/CommonsList.test.js
@@ -89,4 +89,8 @@ describe("CommonsList tests", () => {
             i++;
         })
     });
+    test('displays default message when there are no commons', () => {
+        render(<CommonsList commonList={[]} buttonText = {null} />);
+        expect(screen.getByText(/Currently, there are no commons available./i)).toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I added a message saying "Currently, there are no commons available" when there are no commons to join or visit. 

## Screenshots
<img width="1440" alt="Screenshot 2023-11-21 at 1 29 29 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-2/assets/87053275/522c83e9-0ab2-441b-b2e1-493ab973e727">
<img width="1440" alt="Screenshot 2023-11-21 at 1 29 04 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-2/assets/87053275/b580857b-2d5d-4d3b-9140-2bbfac56596f">
<img width="1440" alt="Screenshot 2023-11-21 at 1 28 24 PM" src="https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-2/assets/87053275/06967e8d-3a09-4f07-8fea-442bb0a5ed3d">

## Validation

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #7 
