### PR TITLE
Chinmay - refactor chattoggle from PlayPage.js into it's own React Component

### DIFF
--- a/frontend/src/main/components/Chat/ChatToggle.js
+++ b/frontend/src/main/components/Chat/ChatToggle.js
@@ -1,0 +1,28 @@
+import Button from "react-bootstrap/Button";
+
+const chatButtonStyle = {
+    width: '40px',
+    height: '40px',
+    borderRadius: '50%',
+    backgroundColor: 'lightblue',
+    color: 'black',
+    position: 'fixed',
+    bottom: '20px',
+    right: '20px',
+  };
+
+
+const ChatToggle = ({ toggleChatWindow }) => 
+{
+    return (
+        <Button
+            style={chatButtonStyle}
+            onClick={toggleChatWindow}
+            data-testid="ChatToggle"
+        >
+            Chat
+        </Button>
+    );
+}
+
+export default ChatToggle;

--- a/frontend/src/main/components/Chat/ChatToggle.js
+++ b/frontend/src/main/components/Chat/ChatToggle.js
@@ -12,7 +12,7 @@ const chatButtonStyle = {
   };
 
 
-const ChatToggle = ({ toggleChatWindow }) => 
+const ChatToggle = ({ toggleChatWindow, isChatOpen }) => 
 {
     return (
         <Button
@@ -20,7 +20,7 @@ const ChatToggle = ({ toggleChatWindow }) =>
             onClick={toggleChatWindow}
             data-testid="ChatToggle"
         >
-            Chat
+            {!isChatOpen? '▲' : '▼'}
         </Button>
     );
 }

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -148,7 +148,7 @@ const onSuccessSell = () => {
       </BasicLayout>
       <div style={chatContainerStyle} data-testid="playpage-chat-div">
         {!!isChatOpen && <ChatPanel commonsId={commonsId}/>}
-        <ChatToggle toggleChatWindow={toggleChatWindow} />
+        <ChatToggle toggleChatWindow={toggleChatWindow} isChatOpen={isChatOpen} />
       </div>
     </div>
   )

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -1,5 +1,5 @@
 import React, {useState} from "react";
-import { Container, CardGroup, Button } from "react-bootstrap";
+import { Container, CardGroup} from "react-bootstrap";
 import { useParams } from "react-router-dom";
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
@@ -12,6 +12,7 @@ import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { useCurrentUser } from "main/utils/currentUser";
 import Background from "../../assets/PlayPageBackground.png";
 import ChatPanel from "main/components/Chat/ChatPanel";
+import ChatToggle from "main/components/Chat/ChatToggle";
 
 export default function PlayPage() {
 
@@ -121,16 +122,6 @@ const onSuccessSell = () => {
     setIsChatOpen((prevState) => !prevState);
   };
 
-  const chatButtonStyle = {
-    width: '40px',
-    height: '40px',
-    borderRadius: '50%',
-    backgroundColor: 'lightblue',
-    color: 'black',
-    position: 'fixed',
-    bottom: '20px',
-    right: '20px',
-  };
 
   const chatContainerStyle = {
     width: '550px',
@@ -157,9 +148,7 @@ const onSuccessSell = () => {
       </BasicLayout>
       <div style={chatContainerStyle} data-testid="playpage-chat-div">
         {!!isChatOpen && <ChatPanel commonsId={commonsId}/>}
-        <Button style={chatButtonStyle} onClick={toggleChatWindow} data-testid="playpage-chat-toggle">
-          {!!isChatOpen ? '▼' : '▲'}
-        </Button>
+        <ChatToggle toggleChatWindow={toggleChatWindow} />
       </div>
     </div>
   )

--- a/frontend/src/stories/components/Chat/ChatToggle.stories.js
+++ b/frontend/src/stories/components/Chat/ChatToggle.stories.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { rest } from 'msw';
 import ChatToggle from "main/components/Chat/ChatToggle";
 
 export default {
@@ -7,11 +6,6 @@ export default {
     component: ChatToggle
 };
 
-const [isChatOpen, setIsChatOpen] = useState(false);
-
-const toggleChatWindow = () => {
-setIsChatOpen((prevState) => !prevState);
-};
 
 const Template = (args) => {
     return (
@@ -19,8 +13,11 @@ const Template = (args) => {
     )
 };
 
+const toggleChatWindow = () => {}
+
 export const Message = Template.bind({});
 
 Message.args = {
     toggleChatWindow: toggleChatWindow,
+    isChatOpen: false
 };

--- a/frontend/src/stories/components/Chat/ChatToggle.stories.js
+++ b/frontend/src/stories/components/Chat/ChatToggle.stories.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { rest } from 'msw';
+import ChatToggle from "main/components/Chat/ChatToggle";
+
+export default {
+    title: 'components/Chat/ChatToggle',
+    component: ChatToggle
+};
+
+const [isChatOpen, setIsChatOpen] = useState(false);
+
+const toggleChatWindow = () => {
+setIsChatOpen((prevState) => !prevState);
+};
+
+const Template = (args) => {
+    return (
+        <ChatToggle {...args} />
+    )
+};
+
+export const Message = Template.bind({});
+
+Message.args = {
+    toggleChatWindow: toggleChatWindow,
+};

--- a/frontend/src/stories/components/Chat/ChatToggle.stories.js
+++ b/frontend/src/stories/components/Chat/ChatToggle.stories.js
@@ -13,7 +13,9 @@ const Template = (args) => {
     )
 };
 
-const toggleChatWindow = () => {}
+const toggleChatWindow = () => {
+    window.alert("chat toggle clicked");
+}
 
 export const Message = Template.bind({});
 

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -132,11 +132,11 @@ describe("PlayPage tests", () => {
         );
 
         await waitFor(() => {
-            expect(screen.getByTestId("playpage-chat-toggle")).toBeInTheDocument();
+            expect(screen.getByTestId("ChatToggle")).toBeInTheDocument();
         });
     
         // Make sure the chat toggle button is visible
-        const chatToggleButton = screen.getByTestId("playpage-chat-toggle");
+        const chatToggleButton = screen.getByTestId("ChatToggle");
         expect(chatToggleButton).toBeInTheDocument();
         
         // Make sure the ChatPanel is not visible initially
@@ -169,19 +169,19 @@ describe("PlayPage tests", () => {
         );
 
         await waitFor(() => {
-            expect(screen.getByTestId("playpage-chat-toggle")).toBeInTheDocument();
+            expect(screen.getByTestId("ChatToggle")).toBeInTheDocument();
         });
 
-        const chatButton = screen.getByTestId("playpage-chat-toggle");
+        const chatButton = screen.getByTestId("ChatToggle");
         const chatContainer = screen.getByTestId("playpage-chat-div");
 
-        expect(chatButton).toHaveTextContent('▲');
+        expect(chatButton).toHaveTextContent('Chat');
 
         // Click the chat toggle button to open the ChatPanel
         fireEvent.click(chatButton);
 
         await waitFor(() => {
-            expect(chatButton).toHaveTextContent('▼');
+            expect(chatButton).toHaveTextContent('Chat');
         });
 
         // Check styles for the chat button

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -175,13 +175,13 @@ describe("PlayPage tests", () => {
         const chatButton = screen.getByTestId("ChatToggle");
         const chatContainer = screen.getByTestId("playpage-chat-div");
 
-        expect(chatButton).toHaveTextContent('Chat');
+        expect(chatButton).toHaveTextContent('▲');
 
         // Click the chat toggle button to open the ChatPanel
         fireEvent.click(chatButton);
 
         await waitFor(() => {
-            expect(chatButton).toHaveTextContent('Chat');
+            expect(chatButton).toHaveTextContent('▼');
         });
 
         // Check styles for the chat button


### PR DESCRIPTION
## Overview
In this PR, I refactored the button to toggle the Chat in PlayPage.js into it's own component, Chat/ChatToggle.js. I also added the necessary storybook for the component and changed PlayPage.test.js to reflect the changes.

Storybook: https://ucsb-cs156-f23.github.io/proj-happycows-f23-5pm-2/prs/36/storybook/?path=/story/components-chat-chattoggle--message

## Screenshots (Optional)
No screenshots since the UI did not change at all.

## Future Possibilities (Optional)
<!--What do you think this project could become? Delete if not needed.-->
Some possible points could be:
- This is the beginning/part of #7 

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to this page.
4. Test this function.


## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #32 
