### PR TITLE
Hancheng sorting

### DIFF
--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -26,7 +26,6 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             },
             sortType: 
                 (rowA,rowB,_id,_desc)=>{
-                    // const diff = parseFloat() - parseFloat(rowB.original.totalWealth);
                     return rowA.original.totalWealth - rowB.original.totalWealth;
                 }
             ,

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -24,10 +24,16 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             accessor: (row, _rowIndex) => {
                 return USD.format(row.totalWealth);
             },
+            sortType: 
+                (rowA,rowB,_id,_desc)=>{
+                    // const diff = parseFloat() - parseFloat(rowB.original.totalWealth);
+                    return rowA.original.totalWealth - rowB.original.totalWealth;
+                }
+            ,
             Cell: (props) => {
                 return (
                   <div style={{textAlign: "right"}}>{props.value}</div>)
-                  },
+            },
         },
         {
             Header: 'Cows Owned',

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -114,11 +114,13 @@ describe("LeaderboardTable tests", () => {
     
   test("renders the correct sorted wealth with click the button", () => {
     const currentUser = currentUserFixtures.adminUser;
-    render(<QueryClientProvider client={queryClient}>
-      <MemoryRouter>
-        <LeaderboardTable leaderboardUsers={leaderboardFixtures.fiveUserCommonsLB} currentUser={currentUser} />
-      </MemoryRouter>
-    </QueryClientProvider>);
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LeaderboardTable leaderboardUsers={leaderboardFixtures.fiveUserCommonsLB} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
 
     fireEvent.click(screen.getByText('Total Wealth'))
     const allTotalWealthCellsInc = screen.getAllByText(/\$\d+(,\d{3})*(\.\d{2})?/);
@@ -136,5 +138,6 @@ describe("LeaderboardTable tests", () => {
     expect(allTotalWealthCellsDec[1]).toHaveTextContent("$1,000.00");
     expect(allTotalWealthCellsDec[0]).toHaveTextContent("$100,000.00");
   });
+
 });
 

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -112,8 +112,8 @@ describe("LeaderboardTable tests", () => {
 
   });
     
-  test('renders the correct sorted wealth with click the button', () => {
-    const currentUser = currentUserFixtures.userOnly;
+  test("renders the correct sorted wealth with click the button", () => {
+    const currentUser = currentUserFixtures.adminUser;
     render(<QueryClientProvider client={queryClient}>
       <MemoryRouter>
         <LeaderboardTable leaderboardUsers={leaderboardFixtures.fiveUserCommonsLB} currentUser={currentUser} />

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import LeaderboardTable from "main/components/Leaderboard/LeaderboardTable";
@@ -112,6 +112,29 @@ describe("LeaderboardTable tests", () => {
 
   });
     
+  test('renders the correct sorted wealth with click the button', () => {
+    const currentUser = currentUserFixtures.userOnly;
+    render(<QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <LeaderboardTable leaderboardUsers={leaderboardFixtures.fiveUserCommonsLB} currentUser={currentUser} />
+      </MemoryRouter>
+    </QueryClientProvider>);
 
+    fireEvent.click(screen.getByText('Total Wealth'))
+    const allTotalWealthCellsInc = screen.getAllByText(/\$\d+(,\d{3})*(\.\d{2})?/);
+    expect(allTotalWealthCellsInc[0]).toHaveTextContent("$50.00");
+    expect(allTotalWealthCellsInc[1]).toHaveTextContent("$800.00");
+    expect(allTotalWealthCellsInc[2]).toHaveTextContent("$1,000.00");
+    expect(allTotalWealthCellsInc[3]).toHaveTextContent("$1,000.00");
+    expect(allTotalWealthCellsInc[4]).toHaveTextContent("$100,000.00");
+
+    fireEvent.click(screen.getByText('Total Wealth'))
+    const allTotalWealthCellsDec = screen.getAllByText(/\$\d+(,\d{3})*(\.\d{2})?/);
+    expect(allTotalWealthCellsDec[4]).toHaveTextContent("$50.00");
+    expect(allTotalWealthCellsDec[3]).toHaveTextContent("$800.00");
+    expect(allTotalWealthCellsDec[2]).toHaveTextContent("$1,000.00");
+    expect(allTotalWealthCellsDec[1]).toHaveTextContent("$1,000.00");
+    expect(allTotalWealthCellsDec[0]).toHaveTextContent("$100,000.00");
+  });
 });
 


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I fixed the bug of total wealth not sorting correctly. 

## Screenshots (Optional)
Before: 
![Screenshot 2023-11-26 at 7 44 35 PM](https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-2/assets/87053275/7d85e3a9-cd3e-4ca1-896b-3d64bcfb235f)
After:
![Screenshot 2023-11-26 at 7 44 45 PM](https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-2/assets/87053275/a616bf2b-ae20-4ee9-bbd8-4e01ab905dd2)

## Validation
You can test it on my dokku development server: 

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #21 
