### PR TITLE
Changed commons form to use default values from /defaults endpoint instead of hard coded values

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ will likely see an error such as:
 
 <img src="https://user-images.githubusercontent.com/1119017/149858436-c9baa238-a4f7-4c52-b995-0ed8bee97487.png" alt="Authorization Error; Error 401: invalid_client; The OAuth client was not found." width="400"/>
 
+# Changing default values for commons fields
+
+To modify default values, look at [`docs/environment.md`](docs/environment.md) for details
+
 # Getting Started on localhost
 
 * Open *two separate terminal windows*  

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,15 @@
+# Environment Variables
+
+HAPPYCOWS_STARTING_BALANCE - used to change default starting balance
+HAPPYCOWS_COW_PRICE - used to change default starting cow price
+HAPPYCOWS_MILK_PRICE - used to change default milk price
+HAPPYCOWS_DEGRADATION_RATE - used to change default degradation rate
+HAPPYCOWS_CARRYING_CAPACITY - used to change default carrying capacity
+HAPPYCOWS_CAPACITY_PER_USER - used to change default capacity per user
+HAPPYCOWS_ABOVE_CAPACITY_HEALTH_UPDATE_STRATEGY - used to change default above capacity strategy
+HAPPYCOWS_BELOW_CAPACITY_HEALTH_UPDATE_STRATEGY - used to change default below capacity strategy
+
+To change these values in the .env file, simply add the variable name={new value you want to use} on a new line
+Ex. HAPPYCOWS_STARTING_BALANCE=50
+
+To change these values from the application.properties file, just change the value on the line for the desired variable

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,13 +1,13 @@
 # Environment Variables
 
-HAPPYCOWS_STARTING_BALANCE - used to change default starting balance
-HAPPYCOWS_COW_PRICE - used to change default starting cow price
-HAPPYCOWS_MILK_PRICE - used to change default milk price
-HAPPYCOWS_DEGRADATION_RATE - used to change default degradation rate
-HAPPYCOWS_CARRYING_CAPACITY - used to change default carrying capacity
-HAPPYCOWS_CAPACITY_PER_USER - used to change default capacity per user
-HAPPYCOWS_ABOVE_CAPACITY_HEALTH_UPDATE_STRATEGY - used to change default above capacity strategy
-HAPPYCOWS_BELOW_CAPACITY_HEALTH_UPDATE_STRATEGY - used to change default below capacity strategy
+- HAPPYCOWS_STARTING_BALANCE - used to change default starting balance
+- HAPPYCOWS_COW_PRICE - used to change default starting cow price
+- HAPPYCOWS_MILK_PRICE - used to change default milk price
+- HAPPYCOWS_DEGRADATION_RATE - used to change default degradation rate
+- HAPPYCOWS_CARRYING_CAPACITY - used to change default carrying capacity
+- HAPPYCOWS_CAPACITY_PER_USER - used to change default capacity per user
+- HAPPYCOWS_ABOVE_CAPACITY_HEALTH_UPDATE_STRATEGY - used to change default above capacity strategy
+- HAPPYCOWS_BELOW_CAPACITY_HEALTH_UPDATE_STRATEGY - used to change default below capacity strategy
 
 To change these values in the .env file, simply add the variable name={new value you want to use} on a new line
 Ex. HAPPYCOWS_STARTING_BALANCE=50

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,13 +1,13 @@
 # Environment Variables
 
-- HAPPYCOWS_STARTING_BALANCE - used to change default starting balance
-- HAPPYCOWS_COW_PRICE - used to change default starting cow price
-- HAPPYCOWS_MILK_PRICE - used to change default milk price
-- HAPPYCOWS_DEGRADATION_RATE - used to change default degradation rate
-- HAPPYCOWS_CARRYING_CAPACITY - used to change default carrying capacity
-- HAPPYCOWS_CAPACITY_PER_USER - used to change default capacity per user
-- HAPPYCOWS_ABOVE_CAPACITY_HEALTH_UPDATE_STRATEGY - used to change default above capacity strategy
-- HAPPYCOWS_BELOW_CAPACITY_HEALTH_UPDATE_STRATEGY - used to change default below capacity strategy
+- HAPPYCOWS_STARTING_BALANCE: used to change default starting balance
+- HAPPYCOWS_COW_PRICE: used to change default starting cow price
+- HAPPYCOWS_MILK_PRICE: used to change default milk price
+- HAPPYCOWS_DEGRADATION_RATE: used to change default degradation rate
+- HAPPYCOWS_CARRYING_CAPACITY: used to change default carrying capacity
+- HAPPYCOWS_CAPACITY_PER_USER: used to change default capacity per user
+- HAPPYCOWS_ABOVE_CAPACITY_HEALTH_UPDATE_STRATEGY: used to change default above capacity strategy
+- HAPPYCOWS_BELOW_CAPACITY_HEALTH_UPDATE_STRATEGY: used to change default below capacity strategy
 
 To change these values in the .env file, simply add the variable name={new value you want to use} on a new line
 Ex. HAPPYCOWS_STARTING_BALANCE=50

--- a/frontend/src/fixtures/commonsFixtures.js
+++ b/frontend/src/fixtures/commonsFixtures.js
@@ -173,6 +173,26 @@ const commonsFixtures = {
             "aboveCapacityHealthUpdateStrategy": "Linear"
         }
     ],
+    defaultCommons:
+    [
+        {
+            "id": 1,
+            "name": "",
+            "day": 1,
+            "startingDate": "2023-11-27T15:50:10",
+            "startingBalance": 10000,
+            "totalPlayers": 100,
+            "cowPrice": 100,
+            "milkPrice": 1,
+            "degradationRate": .001,
+            "showLeaderboard": true,
+            "capacityPerUser": 5,
+            "carryingCapacity": 100,
+            "effectiveCapacity": 100,
+            "belowCapacityHealthUpdateStrategy": "Constant",
+            "aboveCapacityHealthUpdateStrategy": "Linear"
+        }
+    ],
 }
 
 export default commonsFixtures;

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, act } from "@testing-library/react";
 import { MemoryRouter as Router } from "react-router-dom";
 import CommonsForm from "main/components/Commons/CommonsForm";
 import { QueryClient, QueryClientProvider } from "react-query";
@@ -151,7 +151,7 @@ describe("CommonsForm tests", () => {
 
     const curr = new Date();
     const today = curr.toISOString().substr(0, 10);
-    const DefaultVals = {
+    const values = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today
     };
@@ -159,6 +159,10 @@ describe("CommonsForm tests", () => {
     axiosMock
         .onGet("/api/commons/all-health-update-strategies")
         .reply(200, healthUpdateStrategyListFixtures.real);
+
+    axiosMock
+      .onGet("/api/commons/defaults")
+      .reply(200, values);
 
     render(
         <QueryClientProvider client={new QueryClient()}>
@@ -175,7 +179,7 @@ describe("CommonsForm tests", () => {
     ].forEach(
         (item) => {
           const element = screen.getByTestId(`CommonsForm-${item}`);
-          expect(element).toHaveValue(DefaultVals[item]);
+          expect(element).toHaveValue(values[item]);
         }
     );
 
@@ -279,10 +283,21 @@ describe("CommonsForm tests", () => {
   });
 
   it("renders correctly when an initialCommons is not passed in", async () => {
+    const curr = new Date();
+    const today = curr.toISOString().substr(0, 10);
+    const values = {
+      name: "", startingBalance: 10000, cowPrice: 100,
+      milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today,
+      aboveCapacityHealthUpdateStrategy: "Linear", belowCapacityHealthUpdateStrategy: "Constant"
+    };
 
     axiosMock
       .onGet("/api/commons/all-health-update-strategies")
       .reply(200, healthUpdateStrategyListFixtures.real);
+    
+    axiosMock
+      .onGet("/api/commons/defaults")
+      .reply(200, values);
 
     render(
       <QueryClientProvider client={new QueryClient()}>
@@ -290,6 +305,17 @@ describe("CommonsForm tests", () => {
           <CommonsForm />
         </Router>
       </QueryClientProvider>
+    );
+
+    expect(await screen.findByTestId("CommonsForm-name")).toBeInTheDocument();
+    [
+      "name", "degradationRate", "carryingCapacity",
+      "milkPrice","cowPrice","startingBalance","startingDate",
+    ].forEach(
+        (item) => {
+          const element = screen.getByTestId(`CommonsForm-${item}`);
+          expect(element).toHaveValue(values[item]);
+        }
     );
 
     expect(await screen.findByText(/When below capacity/)).toBeInTheDocument();
@@ -300,11 +326,63 @@ describe("CommonsForm tests", () => {
     expect(screen.getByTestId("belowCapacityHealthUpdateStrategy-Constant")).toHaveAttribute("selected");
   });
 
+  it('use default values when initial commons not provided', async () => {
+    const submitAction = jest.fn();
+  
+    axiosMock
+      .onGet("/api/commons/all-health-update-strategies")
+      .reply(200, healthUpdateStrategyListFixtures.real);
+  
+    axiosMock
+      .onGet("/api/commons/defaults")
+      .reply(200, {
+        startingBalance: 500,
+        cowPrice: 32,
+        milkPrice: 0.5,
+        degradationRate: 0.005,
+        carryingCapacity: 500,
+        capacityPerUser: 5,
+        aboveCapacityHealthUpdateStrategy: "Linear",
+        belowCapacityHealthUpdateStrategy: "Constant",
+      });
+  
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <Router>
+          <CommonsForm submitAction={submitAction} />
+        </Router>
+      </QueryClientProvider>
+    );
+  
+    fireEvent.change(screen.getByTestId("CommonsForm-startingBalance"), { target: { value: "0" } });
+    fireEvent.change(screen.getByTestId("CommonsForm-cowPrice"), { target: { value: "0" } });
+    fireEvent.change(screen.getByTestId("CommonsForm-milkPrice"), { target: { value: "0" } });
+    fireEvent.change(screen.getByTestId("CommonsForm-degradationRate"), { target: { value: "0" } });
+    fireEvent.change(screen.getByTestId("CommonsForm-carryingCapacity"), { target: { value: "0" } });
+    fireEvent.change(screen.getByTestId("CommonsForm-capacityPerUser"), { target: { value: "0" } });
+
+    // force invoke useEffect
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  
+    expect(screen.getByTestId('CommonsForm-startingBalance')).toHaveValue(500);
+    expect(screen.getByTestId('CommonsForm-cowPrice')).toHaveValue(32);
+    expect(screen.getByTestId('CommonsForm-milkPrice')).toHaveValue(0.5);
+    expect(screen.getByTestId('CommonsForm-degradationRate')).toHaveValue(0.005);
+    expect(screen.getByTestId('CommonsForm-carryingCapacity')).toHaveValue(500);
+    expect(screen.getByTestId('CommonsForm-capacityPerUser')).toHaveValue(5);
+  });
+  
   test("the correct parameters are passed to useBackend", async () => {
 
     axiosMock
       .onGet("/api/commons/all-health-update-strategies")
       .reply(200, healthUpdateStrategyListFixtures.real);
+    
+    axiosMock
+      .onGet("/api/commons/defaults")
+      .reply(200, commonsFixtures.defaultCommons);;
 
     // https://www.chakshunyu.com/blog/how-to-spy-on-a-named-import-in-jest/
     const useBackendSpy = jest.spyOn(useBackendModule, 'useBackend');
@@ -322,6 +400,14 @@ describe("CommonsForm tests", () => {
         "/api/commons/all-health-update-strategies", {
         method: "GET",
         url: "/api/commons/all-health-update-strategies",
+      },
+      );
+    });
+    await waitFor(() => {
+      expect(useBackendSpy).toHaveBeenCalledWith(
+        "/api/commons/defaults", {
+        method: "GET",
+        url: "/api/commons/defaults",
       },
       );
     });


### PR DESCRIPTION
Changed code in commons form to use the values from the /defaults endpoint instead of the hard coded values. Then, modified the html for each component to use this new value. Had to change the common form test file to account for these changes and also create a new fixture for the last test to pass. Lastly, added a section to the readme for docs/environment.md, which explains what the variables are used for and how to modify them.

This is the issue: https://github.com/orgs/ucsb-cs156-f23/projects/44/views/1?pane=issue&itemId=45052343

To test the changes, checkout to the branch adam-default-frontend and either change the commons values in the application.properties file or from the .env file. The instructions are located in doc/environment.md. Then start up the app locally and see if the new updated values are populated in the create new commons form. For example, in the below image I changed the starting balance to be 100009 in the application.properties file and the change is displayed on the form.

![Screen Shot 2023-11-27 at 10 09 20 PM](https://github.com/ucsb-cs156-f23/proj-happycows-f23-5pm-2/assets/72903615/077c57f3-c1f3-4d99-8878-78d998c09591)

Closes #6 

 